### PR TITLE
fix: add migration for new_sqlite_classes

### DIFF
--- a/wrangler/wrangler.toml
+++ b/wrangler/wrangler.toml
@@ -1,4 +1,4 @@
-name = "planning-poker-worker"
+name = "planning-poker-backend"
 main = "src/index.ts"
 compatibility_date = "2025-01-01"
 
@@ -13,3 +13,7 @@ class_name = "Game"
 [[migrations]]
 tag = "v1"
 new_classes = ["Game"]
+
+[[migrations]]
+tag = "v2"
+new_sqlite_classes = ["Game"]


### PR DESCRIPTION
```
✘ [ERROR] A request to the Cloudflare API (/accounts/***/workers/scripts/planning-poker-worker) failed.

  In order to use Durable Objects with a free plan, you must create a namespace using a `new_sqlite_classes` migration. [code: 10097]
```